### PR TITLE
Prevent single_control and i18n blocks sucking up other ss tags

### DIFF
--- a/syntax/silverstripe.tmLanguage
+++ b/syntax/silverstripe.tmLanguage
@@ -519,7 +519,7 @@
 					<key>comment</key>
 					<string>Translatable text tags</string>
 					<key>match</key>
-					<string>(&lt;%t)(.*)(\s%&gt;)</string>
+					<string>(&lt;%t)(.*?)(\s%&gt;)</string>
 					<key>name</key>
 					<string>source.ss.embedded.i18n</string>
 				</dict>
@@ -751,7 +751,7 @@
 					<key>comment</key>
 					<string>Single control keywords</string>
 					<key>match</key>
-					<string>(&lt;%\s)(else|end_if|control|end_control|with|end_with|Loop|end_Loop|loop|end_loop|base_tag|require|cacheblock|end_cacheblock|cached|end_cached|uncached|end_uncached)(.*)(\s%&gt;)</string>
+					<string>(&lt;%\s)(else|end_if|control|end_control|with|end_with|Loop|end_Loop|loop|end_loop|base_tag|require|cacheblock|end_cacheblock|cached|end_cached|uncached|end_uncached)(.*?)(\s%&gt;)</string>
 					<key>name</key>
 					<string>source.ss.embedded.block</string>
 				</dict>


### PR DESCRIPTION
Fixes an issue that I had, and https://github.com/benjamin-smith/sublime-text-silverstripe/issues/10