### PR TITLE
Case sensitive id in emmet.includeLanguages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add below settings to enable Emmet for blade:
 
 ```json
 "emmet.includeLanguages": {
-    "silverstripe": "html"
+    "SilverStripe": "html"
 },
 "emmet.triggerExpansionOnTab": true,
 ```


### PR DESCRIPTION
I needed to add `SilverStripe` rather than `silverstripe` to get emmet to work correctly (with wrapping).