### PR TITLE
Sanchez v2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Provides [SilverStripe](http://www.silverstripe.org/) syntax highlighting and sn
 - Includes snippets for addons modules such as [tagfield](https://github.com/silverstripe/silverstripe-tagfield) and [linkable](https://github.com/sheadawson/silverstripe-linkable).
 - .ss templates include scope and conditional indentation.
 - .ss templates support go to definition for `<% include %>`, `<% themedCSS %>` and `<% themeJavascript %>`.
-- .ss templates autocomplete paths include, themedCSS and themeJavascript. ie. includepagination will complete to <% include SilverStripe/Blog/Pagination %> if found in the appropriate directory.
+- .ss templates autocomplete paths include, themedCSS and themeJavascript. ie. includepagination will complete to `<% include SilverStripe/Blog/Pagination %>` if found in the appropriate directory.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Provides [SilverStripe](http://www.silverstripe.org/) syntax highlighting and sn
 - Uses full word prefixes so you don't have to remember abbreviations.
 - Includes snippets for addons modules such as [tagfield](https://github.com/silverstripe/silverstripe-tagfield) and [linkable](https://github.com/sheadawson/silverstripe-linkable).
 - .ss templates include scope and conditional indentation.
+- .ss templates support go to definition for `<% include %>`, `<% themedCSS %>` and `<% themeJavascript %>`.
+- .ss templates autocomplete paths include, themedCSS and themeJavascript. ie. includepagination will complete to <% include SilverStripe/Blog/Pagination %> if found in the appropriate directory.
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -93,12 +93,18 @@
           ],
           "default": "null",
           "description": "Enable/Disable if snippets should attempt to inject use item namespacing automatically."
+        },
+        "Silverstripe.showSnippetCount": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Enable/Disable snippet display count on activate."
         }
       }
     }
   },
   "dependencies": {
-    "silverstripe-sanchez": "^1.0.0"
+    "silverstripe-sanchez": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^8.10.25",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { silverstripeCompletionProvider } from './silverstripeCompletionProvider';
+import { silverstripeDefinitionProvider } from './silverstripeDefinitionProvider';
 
 const Enginez = require('silverstripe-sanchez');
 let sanchez = null;
@@ -88,6 +89,12 @@ export function activate(context: vscode.ExtensionContext) {
           )
         })
       }
+    )
+  )
+  context.subscriptions.push(
+    vscode.languages.registerDefinitionProvider(
+      { scheme: "file", language: "silverstripe" },
+      new silverstripeDefinitionProvider(sanchez)
     )
   )
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,39 +25,46 @@ export function activate(context: vscode.ExtensionContext) {
   // if null use `.silverstripe_sanchez` file config if available either in
   // the home directory or active project
   if (vsconfig.comments === 'null') {
-    delete vsconfig.comments
+    delete vsconfig.comments;
   };
 
   // if null use `.silverstripe_sanchez` file config if available either in
   // the home directory or active project
   if (vsconfig.useItems === 'null') {
-    delete vsconfig.useItems
+    delete vsconfig.useItems;
   };
 
   sanchez = new Enginez({
-    // .silverstripe_sanchez
-    configPaths: paths,
-    // composer.lock
-    composerPaths: paths,
-    // package-lock.json
-    nodePaths: paths,
+    rootPaths: paths,
     // VsCode settings override .silverstripe_sanchez
     config: vsconfig
   });
 
-  // Output snippet count incase of future issues,
-  // may remove in future if happy we don't have
-  // more issues.
-  const foundSnippets = sanchez.snippets({
-    prefix: true,
-    scope: true,
-    language: true
-  }).length
-  const totalSnippets = sanchez.allSnippets.length
+  // Read _config yaml files.
+  sanchez.readConfig();
 
-  vscode.window.showInformationMessage(
-    `${foundSnippets} Silverstripe snippets available from a total of ${totalSnippets} found.`,
-  );
+  // Index theme files.
+  sanchez.indexTheme();
+
+  // Build additional theme snippets based on themeindex.
+  // e.g. includepagination will complete to <% include SilverStripe/Blog/Pagination %>
+  sanchez.buildThemeSnippets();
+
+  if (config.get('showSnippetCount')) {
+    // Output snippet count incase of future issues,
+    // may remove in future if happy we don't have
+    // more issues.
+    const foundSnippets = sanchez.snippets({
+      prefix: true,
+      scope: true,
+      language: true
+    }).length;
+    const totalSnippets = sanchez.allSnippets.length;
+
+    vscode.window.showInformationMessage(
+      `${foundSnippets} Silverstripe snippets available from a total of ${totalSnippets} found.`
+    );
+  }
 
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
@@ -71,6 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
       '.'
     )
   )
+
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand(
       'silverstripe.injectUseItems',
@@ -91,6 +99,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   )
+
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider(
       { scheme: "file", language: "silverstripe" },

--- a/src/silverstripeDefinitionProvider.ts
+++ b/src/silverstripeDefinitionProvider.ts
@@ -11,18 +11,36 @@ export class silverstripeDefinitionProvider implements vscode.DefinitionProvider
   public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Definition> {
     const workspace = vscode.workspace.getWorkspaceFolder(document.uri);
     const root = workspace ? workspace.uri : document.uri;
-    console.log(workspace, root, document, position);
+    const range = document.getWordRangeAtPosition(position, /include \S*|themed(?:CSS|Javascript)\(["']+\S*["']+\)/);
+    const text = document.getText(range);
+    let parts = [];
 
-    // const includePath = this.sanchez.getIncludePath(root, document.getText(), position); // @todo Get sanchez to index all .ss files and find the best match.
-    const includePath = false
+    if (text.startsWith('include')) {
+      parts = text.split(' ')
+    }
 
-    if (!includePath) {
+    if (text.startsWith('themedCSS')) {
+      parts = text.match(/\(["']+(.*)["']+\)/)
+      parts[0] = 'themedCSS'
+    }
+
+    if (text.startsWith('themedJavascript')) {
+      parts = text.match(/\(["']+(.*)["']+\)/)
+      parts[0] = 'themedJavascript'
+    }
+
+    const definitionPath = this.sanchez.getDefinitionPath({
+      type: parts[0],
+      definition: parts[1]
+    });
+
+    if (!definitionPath) {
       return null;
     }
 
     return new vscode.Location(
       root.with({
-          path: path.join(root.path, includePath)
+          path: path.join(definitionPath)
       }),
       new vscode.Position(0, 0)
     );

--- a/src/silverstripeDefinitionProvider.ts
+++ b/src/silverstripeDefinitionProvider.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export class silverstripeDefinitionProvider implements vscode.DefinitionProvider {
+  private sanchez;
+
+  public constructor(sanchez) {
+    this.sanchez = sanchez;
+  }
+
+  public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Definition> {
+    const workspace = vscode.workspace.getWorkspaceFolder(document.uri);
+    const root = workspace ? workspace.uri : document.uri;
+    console.log(workspace, root, document, position);
+
+    // const includePath = this.sanchez.getIncludePath(root, document.getText(), position); // @todo Get sanchez to index all .ss files and find the best match.
+    const includePath = false
+
+    if (!includePath) {
+      return null;
+    }
+
+    return new vscode.Location(
+      root.with({
+          path: path.join(root.path, includePath)
+      }),
+      new vscode.Position(0, 0)
+    );
+  };
+}


### PR DESCRIPTION
Improved composer detection
Improved node detection
Added feature go to definition
Added ss template include, themeCSS and themeJavascript snippets
Added toggle to hide snippet count
Added behaviour option when composer and/or node packages aren't found.  Either allowing all or no snippets if packages aren't found.